### PR TITLE
Fix #14: editor.Edit nao propaga stderr do editor (erros silenciados)

### DIFF
--- a/pkg/editor/editor.go
+++ b/pkg/editor/editor.go
@@ -28,6 +28,7 @@ func Edit(file string) error {
 	cmd := exec.Command(command, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 


### PR DESCRIPTION
## Summary

Add `cmd.Stderr = os.Stderr` to the editor command setup so that editor error output is propagated to the user's terminal instead of being silently discarded.

## Approach

In the `Edit` function in `pkg/editor/editor.go`, add `cmd.Stderr = os.Stderr` alongside the existing `cmd.Stdin` and `cmd.Stdout` assignments. This is a single-line addition that connects the editor subprocess's stderr to the user's terminal.

## Files Changed

- `pkg/editor/editor.go`

## Related Issue

Fixes #14

## Testing

Verified the change manually. Let me know if you'd like any additional tests or adjustments.
